### PR TITLE
Add clean_key option

### DIFF
--- a/app/tanium/bin/tanium_nlp.py
+++ b/app/tanium/bin/tanium_nlp.py
@@ -85,7 +85,7 @@ class TaniumQuestion:
         return data
 
 
-    def xml_from_tanium_to_csv_list(self, xml):
+    def xml_from_tanium_to_csv_list(self, xml, clean_key):
         root = ET.fromstring(xml)
         result_list = []
         col_head = ""
@@ -98,6 +98,8 @@ class TaniumQuestion:
             for col_name in col_group.findall(".//dn"):
                 col_head = col_head + "," + col_name.text
             col_head = col_head.lstrip(",")
+            if clean_key == True:
+                col_head = col_head.replace(' ','_')
 
         result_list.append(col_head)
 
@@ -438,6 +440,13 @@ def main():
             default="443",
             help='Splunk server TCP port')
 
+    parser.add_argument(
+            '--clean_key',
+            metavar='(True|False)',
+            required=False,
+            default="True",
+            help='Controls for key clearning')
+
     args = vars(parser.parse_args())
 
     tanium = tanium_server
@@ -448,7 +457,10 @@ def main():
     show_parse = args['show_parse']
     splunk = args['splunk']
     splunk_port = int(args['splunk_port'])
-
+    if args['clean_key'].lower() == "true":
+        clean_key = True
+    else:
+        clean_key = False
 
     # end processing args now inst the Tanium class
     my_tanium = TaniumQuestion(tanium, user, password)
@@ -462,7 +474,7 @@ def main():
         print "The request timed out, Try setting a higher timeout"
     else:
         # translate the results to a user friendly list.
-        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response)
+        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response, clean_key)
 
         list_line = ""
         list_count = 0

--- a/app/tanium/bin/tanium_nlp.py
+++ b/app/tanium/bin/tanium_nlp.py
@@ -445,7 +445,7 @@ def main():
             metavar='(True|False)',
             required=False,
             default="True",
-            help='Controls for key clearning')
+            help='Controls for key cleaning')
 
     args = vars(parser.parse_args())
 

--- a/app/tanium/bin/tanium_prochash.py
+++ b/app/tanium/bin/tanium_prochash.py
@@ -69,7 +69,7 @@ class TaniumQuestion:
         webservice.close()
         return data
 
-    def xml_from_tanium_to_csv_list (self,xml):
+    def xml_from_tanium_to_csv_list (self,xml, clean_key):
         
         root        = ET.fromstring(xml)
         result_list = []    
@@ -83,6 +83,8 @@ class TaniumQuestion:
             for col_name in col_group.findall(".//dn"):
                 col_head = col_head + "," + col_name.text
             col_head = col_head.lstrip(",")
+            if clean_key == True:
+                col_head = col_head.replace(' ','_')
         
         result_list.append(col_head)
             
@@ -250,6 +252,13 @@ def main ():
         default = "3",
         help = 'sensor poll timeout')
         
+    parser.add_argument(
+            '--clean_key',
+            metavar='(True|False)',
+            required=False,
+            default="True",
+            help='Controls for key clearning')
+         
     args = vars(parser.parse_args())
     
     tanium   = args['tanium']
@@ -257,6 +266,10 @@ def main ():
     password = args['password']
     sensors  = ["Running Processes with MD5 Hash","IP Address"]
     timeout  = args['timeout']
+    if args['clean_key'].lower() == "true":
+        clean_key = True
+    else:
+        clean_key = False
     
     #end processing args now inst the Tanium class
     my_tanium = TaniumQuestion(tanium,user,password)
@@ -270,7 +283,7 @@ def main ():
         print "The request timed out, Try setting a higher timeout"
     else:
         #translate the results to a user friendly list.
-        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response)
+        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response, clean_key)
         
         list_line  = ""
         list_count = 0

--- a/app/tanium/bin/tanium_prochash.py
+++ b/app/tanium/bin/tanium_prochash.py
@@ -257,7 +257,7 @@ def main ():
             metavar='(True|False)',
             required=False,
             default="True",
-            help='Controls for key clearning')
+            help='Controls for key cleaning')
          
     args = vars(parser.parse_args())
     

--- a/app/tanium/bin/tanium_run_saved.py
+++ b/app/tanium/bin/tanium_run_saved.py
@@ -81,7 +81,7 @@ class TaniumQuestion:
         webservice.close()
         return data
 
-    def xml_from_tanium_to_csv_list(self, xml, clear_key):
+    def xml_from_tanium_to_csv_list(self, xml, clean_key):
 
         root = ET.fromstring(xml)
         result_list = []
@@ -370,7 +370,7 @@ def main():
             metavar='(True|False)',
             required=False,
             default="True",
-            help='Controls for key clearning')
+            help='Controls for key cleaning')
 
     args = vars(parser.parse_args())
 

--- a/app/tanium/bin/tanium_run_saved.py
+++ b/app/tanium/bin/tanium_run_saved.py
@@ -81,7 +81,7 @@ class TaniumQuestion:
         webservice.close()
         return data
 
-    def xml_from_tanium_to_csv_list(self, xml):
+    def xml_from_tanium_to_csv_list(self, xml, clear_key):
 
         root = ET.fromstring(xml)
         result_list = []
@@ -95,6 +95,8 @@ class TaniumQuestion:
             for col_name in col_group.findall(".//dn"):
                 col_head = col_head + "," + col_name.text
             col_head = col_head.lstrip(",")
+            if clean_key == True:
+                col_head = col_head.replace(' ','_')
 
         result_list.append(col_head)
 
@@ -363,6 +365,13 @@ def main():
             default="9999",
             help='Splunk server TCP port')
 
+    parser.add_argument(
+            '--clean_key',
+            metavar='(True|False)',
+            required=False,
+            default="True",
+            help='Controls for key clearning')
+
     args = vars(parser.parse_args())
 
     tanium = tanium_server
@@ -372,6 +381,10 @@ def main():
     timeout = args['timeout']
     splunk = args['splunk']
     splunk_port = int(args['splunk_port'])
+    if args['clean_key'].lower() == "true":
+        clean_key = True
+    else:
+        clean_key = False
 
     # end processing args now inst the Tanium class
     my_tanium = TaniumQuestion(tanium, user, password)
@@ -385,7 +398,7 @@ def main():
         print "The request timed out, Try setting a higher timeout"
     else:
         # translate the results to a user friendly list.
-        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response)
+        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response, clean_key)
 
         list_line = ""
         list_count = 0

--- a/app/tanium/bin/tanium_run_sensor.py
+++ b/app/tanium/bin/tanium_run_sensor.py
@@ -78,7 +78,7 @@ class TaniumQuestion:
         webservice.close()
         return data
 
-    def xml_from_tanium_to_csv_list(self, xml):
+    def xml_from_tanium_to_csv_list(self, xml, clear_key):
 
         root = ET.fromstring(xml)
         result_list = []
@@ -92,6 +92,8 @@ class TaniumQuestion:
             for col_name in col_group.findall(".//dn"):
                 col_head = col_head + "," + col_name.text
             col_head = col_head.lstrip(",")
+            if clean_key == True:
+                col_head = col_head.replace(' ','_')
 
         result_list.append(col_head)
 
@@ -363,6 +365,13 @@ def main():
             default="9999",
             help='Splunk server TCP port')
 
+    parser.add_argument(
+            '--clean_key',
+            metavar='(True|False)',
+            required=False,
+            default="True",
+            help='Controls for key clearning')
+
     args = vars(parser.parse_args())
 
     tanium = tanium_server
@@ -372,6 +381,10 @@ def main():
     timeout = args['timeout']
     splunk = args['splunk']
     splunk_port = int(args['splunk_port'])
+    if args['clean_key'].lower() == "true":
+        clean_key = True
+    else:
+        clean_key = False
 
     # end processing args now inst the Tanium class
     my_tanium = TaniumQuestion(tanium, user, password)
@@ -385,7 +398,7 @@ def main():
         print "The request timed out, Try setting a higher timeout"
     else:
         # translate the results to a user friendly list.
-        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response)
+        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response, clear_key)
 
         list_line = ""
         list_count = 0

--- a/app/tanium/bin/tanium_run_sensor.py
+++ b/app/tanium/bin/tanium_run_sensor.py
@@ -78,7 +78,7 @@ class TaniumQuestion:
         webservice.close()
         return data
 
-    def xml_from_tanium_to_csv_list(self, xml, clear_key):
+    def xml_from_tanium_to_csv_list(self, xml, clean_key):
 
         root = ET.fromstring(xml)
         result_list = []
@@ -370,7 +370,7 @@ def main():
             metavar='(True|False)',
             required=False,
             default="True",
-            help='Controls for key clearning')
+            help='Controls for key cleaning')
 
     args = vars(parser.parse_args())
 
@@ -398,7 +398,7 @@ def main():
         print "The request timed out, Try setting a higher timeout"
     else:
         # translate the results to a user friendly list.
-        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response, clear_key)
+        list_response = my_tanium.xml_from_tanium_to_csv_list(xml_response, clean_key)
 
         list_line = ""
         list_count = 0


### PR DESCRIPTION
Splunk can handle key/field names having " "(space) characters. But
these are some limitations. So I add a new "clean_key" option to replace
" "(space) to "_"(underscore) in each key/field names.